### PR TITLE
Updating to OpenDistro 1.2.0

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -49,7 +49,7 @@ services:
 
   nlp-medcat-umls:
     #ports:
-      #- "8096:5000"
+    #  - "8096-9000:5000"
     expose:
       - 5000
 
@@ -95,7 +95,6 @@ services:
     expose:
       - 8080
       - 10000 # needed for site-to-site functionality 
-
 
 #---------------------------------------------------------------------------#
 # NGINX reverse-proxy                                                       #

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -49,7 +49,7 @@ services:
 
   nlp-medcat-umls:
     #ports:
-    #  - "8096-9000:5000"
+    #  - "8096:5000"
     expose:
       - 5000
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
 # ElasticSearch cluster                                                     #
 #---------------------------------------------------------------------------#
   elasticsearch-1:
-    image: amazon/opendistro-for-elasticsearch:0.8.0
+    image: amazon/opendistro-for-elasticsearch:1.2.0
     #container_name: elasticsearch-1
     restart: always
     environment:
@@ -92,12 +92,6 @@ services:
       memlock:
         soft: -1
         hard: -1
-    #ports:
-      #- 9200:9200
-      #- 9600:9600
-    #expose:
-    #  - 9200
-    #  - 9600
     networks:
       - esnet
 
@@ -106,10 +100,11 @@ services:
 # Kibana webapp                                                             #
 #---------------------------------------------------------------------------#
   kibana:
-    image: amazon/opendistro-for-elasticsearch-kibana:0.8.0
+    image: amazon/opendistro-for-elasticsearch-kibana:1.2.0
     restart: always
     environment:
       ELASTICSEARCH_URL: http://elasticsearch-1:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch-1:9200
       SERVER_SSL_KEY: /usr/share/kibana/config/kibana.key
       SERVER_SSL_CERTIFICATE: /usr/share/kibana/config/kibana.pem
     depends_on:
@@ -121,10 +116,6 @@ services:
       - ./security/root-ca.pem:/usr/share/kibana/config/root-ca.pem:ro
       - ./security/kibana.pem:/usr/share/kibana/config/kibana.pem:ro
       - ./security/kibana.key:/usr/share/kibana/config/kibana.key:ro
-    #ports:
-      #- 5601:5601
-    #expose:
-    #  - 5601
     networks:
       - esnet
 
@@ -156,12 +147,6 @@ services:
       - nifi-vol-content:/opt/nifi/nifi-current/content_repository
       # errors generated during data processing
       - nifi-vol-errors:/opt/nifi/pipeline/flowfile-errors
-    #ports:
-      #- "8090:8080"
-      #- "8080:8080"
-    #expose:
-    #  - 8080
-    #  - 10000 # site-to-site functionality 
     networks:
       - cognet
       - esnet

--- a/services/elasticsearch/config/elasticsearch.yml
+++ b/services/elasticsearch/config/elasticsearch.yml
@@ -1,26 +1,36 @@
 cluster.name: "docker-cluster"
 network.host: 0.0.0.0
 
+# # minimum_master_nodes need to be explicitly set when bound on a public IP
+# # set to 1 to allow single node clusters
+# # Details: https://github.com/elastic/elasticsearch/pull/17288
 # minimum_master_nodes need to be explicitly set when bound on a public IP
 # set to 1 to allow single node clusters
-# Details: https://github.com/elastic/elasticsearch/pull/17288
 discovery.zen.minimum_master_nodes: 1
 
+# # Breaking change in 7.0
+# # https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#breaking_70_discovery_changes
+# cluster.initial_master_nodes: 
+#    - elasticsearch1
+#    - docker-test-node-1 
+
+
+######## Start OpenDistro for Elasticsearch Security Demo Configuration ########
 # WARNING: revise all the lines below before you go into production
 opendistro_security.ssl.transport.pemcert_filepath: esnode.pem
 opendistro_security.ssl.transport.pemkey_filepath: esnode.key
 opendistro_security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
 opendistro_security.ssl.transport.enforce_hostname_verification: false
+#opendistro_security.ssl.http.enabled: true
 
-# disabled SSL -- set as docker-compose parameter
-#opendistro_security.ssl.http.enabled: false
 opendistro_security.ssl.http.pemcert_filepath: esnode.pem
 opendistro_security.ssl.http.pemkey_filepath: esnode.key
 opendistro_security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+#opendistro_security.allow_unsafe_democertificates: true
 opendistro_security.allow_default_init_securityindex: true
 opendistro_security.authcz.admin_dn:
 #  - CN=kirk,OU=client,O=client,L=test, C=de
-  - 'CN=cogstack'
+  - 'CN=cogstack' 
 
 opendistro_security.nodes_dn:
   - 'CN=elasticsearch-*'
@@ -31,3 +41,4 @@ opendistro_security.check_snapshot_restore_write_privileges: true
 opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
 cluster.routing.allocation.disk.threshold_enabled: false
 node.max_local_storage_nodes: 3
+######## End OpenDistro for Elasticsearch Security Demo Configuration ########


### PR DESCRIPTION
Updating OpenDistro to 1.2.0 from 0.8.0. OpenDistro 1.2.0 fixes numerous issues and already uses ElasticSearch 7.2.0.