### PR TITLE
Simplify ES Docker configuration

### DIFF
--- a/deploy/.env-example
+++ b/deploy/.env-example
@@ -9,7 +9,6 @@ NIFI_ENV_FILE=../security/nifi.env-example
 NIFI_SECURITY_DIR=../security/
 
 # Elasticsearch
-ELASTICSEARCH_ENV_FILE=../security/elasticsearch.env-example
 ELASTICSEARCH_SECURITY_DIR=../security/
 
 # define below the local paths for NLP resources

--- a/deploy/services.yml
+++ b/deploy/services.yml
@@ -297,8 +297,6 @@ services:
       
       - logger.level=INFO
 
-    #env_file:
-    #  - ${ELASTICSEARCH_ENV_FILE}
     volumes:
       # INFO: ES configuration mapped via volume (make sure to comment this and uncomment the next line if you are using NATIVE elasticsearch deployment)
       - ../services/elasticsearch/config/elasticsearch_opensearch.yml:/usr/share/opensearch/config/opensearch.yml:ro

--- a/docs/deploy/main.md
+++ b/docs/deploy/main.md
@@ -37,14 +37,12 @@ For custom deployments, copy `.env-examples` files to `.env` (which are not trac
 ```bash
 cp deploy/.env-example deploy/.env
 cp security/nifi.env-example security/nifi.env
-cp security/elasticsearch.env-example security/elasticsearch.env
 ```
 
 ### Multiple deployments on the same machine
-When deploying multiple docker-compose projects on the same machine (e.g. for dev or testing), it can be useful to remove all containers, volume and network names from the docker-compose file, and let [Docker create names](https://docs.docker.com/compose/reference/envvars/#compose_project_name) based on `COMPOSE_PROJECT_NAME` in `deploy/.env`. You will also need add this project name as prefix and `_1` as suffix to URLs when connecting containers. For example, the Kibana service should contain:
-```yml
-ELASTICSEARCH_URL: http://${COMPOSE_PROJECT_NAME}_elasticsearch-1_1:9200
-```
+When deploying multiple docker-compose projects on the same machine (e.g. for dev or testing), it can be useful to remove all containers, volume and network names from the docker-compose file, and let [Docker create names](https://docs.docker.com/compose/reference/envvars/#compose_project_name) based on `COMPOSE_PROJECT_NAME` in `deploy/.env`. Docker will automatically create a Docker network and makes sure that containers can find each other by container name.
+
+For example, when setting `COMPOSE_PROJECT_NAME=cogstack-prod`, Docker Compose will create a container named `cogstack-prod_elasticsearch-1_1` for the `elasticsearch-1` service. Within the NiFi container, which is running in the same Docker network, you can refer to that container using just the service name `elasticsearch-1`.
 
 ## Troubleshooting
 

--- a/security/elasticsearch.env-example
+++ b/security/elasticsearch.env-example
@@ -1,8 +1,0 @@
-#opendistro_security.ssl.transport.keystore_filepath=/usr/share/elasticsearch/config/keystore.jks
-#opendistro_security.ssl.transport.keystore_password=
-#opendistro_security.ssl.transport.truststore_filepath=/usr/share/elasticsearch/config/truststore.jks
-#opendistro_security.ssl.transport.truststore_password=
-#opendistro_security.ssl.http.keystore_filepath=/usr/share/elasticsearch/config/keystore.jks
-#opendistro_security.ssl.http.keystore_password=
-#opendistro_security.ssl.http.truststore_filepath=/usr/share/elasticsearch/config/truststore.jks
-#opendistro_security.ssl.http.truststore_password=


### PR DESCRIPTION
Hi CogStack team, a few months I suggested to use a `.env`-file for configuring OpenSearch/ElasticSearch, but that was before I understood the potential of the OpenSearch-provided YML file, in this case `elasticsearch_opensearch.yml`. It's pretty well documented how the security properties can fit in the YML file: https://opensearch.org/docs/latest/opensearch/install/docker-security/  . With only a few ENV vars in the documented example's docker-compose, I'm not sure having a seperate`.env` for that is too much added complexity.

I've also updated the documentation in which I corrected some information on how to use the env variable `COMPOSE_PROJECT_NAME`.