### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/nifi/user_python_extensions/record_add_geolocation.py
+++ b/nifi/user_python_extensions/record_add_geolocation.py
@@ -194,7 +194,7 @@ class CogStackJsonRecordAddGeolocation(BaseNiFiProcessor):
                         try:
                             record[self.geolocation_field_name] = f"{float(_lat)},{float(_long)}"   
                         except ValueError:
-                            self.logger.debug(f"invalid lat/long values for postcode {_postcode}: {_lat}, {_long}")
+                            self.logger.debug("invalid lat/long values encountered for a record; geolocation not set")
                             error_records.append(record)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/CogStack/CogStack-NiFi/security/code-scanning/18](https://github.com/CogStack/CogStack-NiFi/security/code-scanning/18)

To fix this without changing functionality, keep the error handling behavior exactly the same but stop logging raw `_postcode`, `_lat`, and `_long` values. Replace the current debug line with a generic message that indicates invalid geolocation data was encountered, without embedding record-derived content.

Best single change:
- **File:** `nifi/user_python_extensions/record_add_geolocation.py`
- **Region:** inside `process(...)`, in the `except ValueError:` block around line 197.
- Replace:
  - `self.logger.debug(f"invalid lat/long values for postcode {_postcode}: {_lat}, {_long}")`
- With:
  - `self.logger.debug("invalid lat/long values encountered for a record; geolocation not set")`

No imports, new methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
